### PR TITLE
Setup health indicators, application info and metrics via spring-boot-actuator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ hs_err_pid*
 **/.settings/
 **/target/
 **/erl_crash.dump
+**/rod.log

--- a/rod-core/src/main/java/rod/RodProperties.java
+++ b/rod-core/src/main/java/rod/RodProperties.java
@@ -1,11 +1,7 @@
 package rod;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RodProperties {
-
-    private static final Logger logger = LoggerFactory.getLogger(RodProperties.class);
 
     public static final String ROD_COMMAND_RABBITMQSERVER = "rod.command.rabbitmqserver";
     public static final String ROD_COMMAND_RABBITMQSERVER_ARGUMENTS = "rod.command.rabbitmqserver.args";

--- a/rod-server/pom.xml
+++ b/rod-server/pom.xml
@@ -68,6 +68,13 @@
         <configuration>
           <addResources>false</addResources>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/rod-server/pom.xml
+++ b/rod-server/pom.xml
@@ -65,6 +65,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <addResources>false</addResources>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/rod-server/pom.xml
+++ b/rod-server/pom.xml
@@ -55,6 +55,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/rod-server/src/main/java/rod/ResourceRepository.java
+++ b/rod-server/src/main/java/rod/ResourceRepository.java
@@ -3,15 +3,25 @@ package rod;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class ResourceRepository {
 
     private final Map<String, Resource> resources = new HashMap<>();
+    private final GaugeService gaugeService;
+
+    @Autowired
+    public ResourceRepository(final GaugeService gaugeService) {
+        this.gaugeService = gaugeService;
+        gaugeService.submit("gauge.repository.resource.count", resourceCount());
+    }
 
     public void save(final Resource resource) {
         resources.put(resource.getName(), resource);
+        gaugeService.submit("gauge.repository.resource.count", resourceCount());
     }
 
     public int resourceCount() {

--- a/rod-server/src/main/java/rod/RodHealthIndicator.java
+++ b/rod-server/src/main/java/rod/RodHealthIndicator.java
@@ -1,0 +1,15 @@
+package rod;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RodHealthIndicator implements HealthIndicator {
+
+    @Override
+    public Health health() {
+        return Health.up().build();
+    }
+
+}

--- a/rod-server/src/main/resources/application.yml
+++ b/rod-server/src/main/resources/application.yml
@@ -1,3 +1,13 @@
+info:
+  build:
+    artifact: ${project.artifactId}
+    name: ${project.name}
+    build.version: ${project.version}
+  app:
+    name: ROD
+    description: Robot On Duty
+    version: ${project.version}
+
 management:
   health:
     rabbit:

--- a/rod-server/src/main/resources/application.yml
+++ b/rod-server/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+management:
+  health:
+    rabbit:
+      enabled: false
+
+endpoints:
+  health:
+    enabled: yes
+    sensitive: true
+
+logging:
+  file: rod.log

--- a/rod-server/src/test/java/rod/RodServerIT.java
+++ b/rod-server/src/test/java/rod/RodServerIT.java
@@ -1,0 +1,22 @@
+package rod;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.web.client.RestTemplate;
+
+public class RodServerIT extends RodServer {
+
+    @Test
+    public void testHealthIndicator() {
+        RodServer.main(new String[] {});
+
+        final RestTemplate template = new TestRestTemplate();
+        final String body = template.getForEntity("http://localhost:8080/health", String.class).getBody();
+
+        assertThat(body, equalTo("{\"status\":\"UP\"}"));
+    }
+
+}


### PR DESCRIPTION
Spring Boot provides an `health` endpoint to monitor application health status.

This PR does the following:
- Adds a ROD specific health indicator (always reporting UP, for now) and disables the RabbitMQ health indicator (for now).
- Adds application and build info to configuration file
- Adds an application metric that counts the number of resources in the repository
- Configures maven to package rod-server as an executable jar

Closes #10 
