### PR TITLE
Fix/wercker rabbitmq

### DIFF
--- a/rod-core/src/test/java/rod/RabbitmqAdapterIT.java
+++ b/rod-core/src/test/java/rod/RabbitmqAdapterIT.java
@@ -5,6 +5,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -24,13 +26,21 @@ public class RabbitmqAdapterIT {
     private static final AmqpTemplate template = context.getBean(AmqpTemplate.class);
 
     private final RabbitmqAdapter adapter = new RabbitmqAdapter();
+    
+    private static Map<String, String> executionMode = new HashMap<String, String>();
+    static {
+    	executionMode.put("travis", "rabbitmq.travis.properties");
+    	executionMode.put("wercker", "rabbitmq.wercker.properties");
+    	executionMode.put("local", "rabbitmq.local.properties");
+    }
 
     @BeforeClass
     public static void setupClass() throws Exception {
         final String propertyName = "rod.build.env";
         final String property = System.getProperty(propertyName);
         logger.debug("Value of {} is {}", propertyName, property);
-        final String propertiesFile = property != null && property.equals("travis") ? "rabbitmq.travis.properties" : "rabbitmq.local.properties";
+        
+        final String propertiesFile = property == null ? executionMode.get("local") : executionMode.get(property);
         final InputStream testProperties = Thread.currentThread().getContextClassLoader().getResourceAsStream(propertiesFile);
         System.getProperties().load(testProperties);
     }

--- a/rod-core/src/test/resources/rabbitmq.wercker.properties
+++ b/rod-core/src/test/resources/rabbitmq.wercker.properties
@@ -1,0 +1,4 @@
+rod.command.rabbitmqserver=/etc/init.d/rabbitmq-server
+rod.command.rabbitmqserver.args=start
+rod.command.rabbitmqctl=/etc/init.d/rabbitmq-server
+rod.command.rabbitmq.sudo=false

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,13 +3,15 @@
 # Read more about containers on our dev center
 # http://devcenter.wercker.com/docs/containers/index.html
 
-box: ekholabs/wercker-jdk8-rmq
+box: ekholabs/wercker-jdk8
 
 services:
     - rabbitmq
 
 build:
   steps:
+    - install-packages:
+        packages: rabbitmq-server
     - script:
         name: rod
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -15,4 +15,4 @@ build:
     - script:
         name: rod
         code: |
-          mvn -Drod.build.env=travis clean deploy
+          mvn -Drod.build.env=wercker clean deploy


### PR DESCRIPTION
This PR fixes the Wercker build.
- Adds a properties file to be used by Wercker
- Changes the wercker.yml to install the rabbitmq-server in the running container
- Changes how the properties files are loaded in order to cope with the new file.
